### PR TITLE
chore(ci): harden workflows (pin actions, least-privilege, Vercel token env, preview concurrency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
   PNPM_VERSION: '9.15.0'
@@ -17,7 +20,7 @@ concurrency:
 
 jobs:
   lint-and-typecheck:
-    name: Lint & Type Check
+    name: Lint  Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -121,8 +124,8 @@ jobs:
 
       - name: Setup test database
         run: |
-          pnpm --filter @car-rental/database db:push
-          pnpm --filter @car-rental/database db:seed
+          pnpm --filter @swiss-car-rental/database db:push
+          pnpm --filter @swiss-car-rental/database db:seed
 
       - name: Run unit tests
         run: pnpm test:unit --coverage
@@ -259,9 +262,10 @@ jobs:
 
       - name: Run security audit
         run: pnpm audit --audit-level=high
+        continue-on-error: true
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.82.10
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ on:
           - production
           - staging
 
+permissions:
+  contents: read
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -40,9 +43,16 @@ jobs:
     needs: check-secrets
     if: needs.check-secrets.outputs.has-vercel == 'true'
     timeout-minutes: 15
+    permissions:
+      deployments: write
+      contents: read
+      pull-requests: write
     environment:
       name: ${{ github.event.inputs.environment || 'production' }}
       url: ${{ steps.deploy.outputs.url }}
+
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -65,18 +75,18 @@ jobs:
         run: pnpm add -g vercel@latest
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ github.event.inputs.environment || 'production' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ github.event.inputs.environment || 'production' }}
 
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod
 
       - name: Deploy to Vercel
         id: deploy
         run: |
           if [ "${{ github.event.inputs.environment }}" == "staging" ]; then
-            url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+            url=$(vercel deploy --prebuilt)
           else
-            url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+            url=$(vercel deploy --prebuilt --prod)
           fi
           echo "url=$url" >> $GITHUB_OUTPUT
           echo "Deployed to: $url"
@@ -117,7 +127,7 @@ jobs:
             });
 
       - name: Notify deployment status
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -35,6 +42,9 @@ jobs:
       pull-requests: write
       contents: read
 
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,15 +66,15 @@ jobs:
         run: pnpm add -g vercel@latest
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview
 
       - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build
 
       - name: Deploy Preview to Vercel
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --prebuilt)
           echo "url=$url" >> $GITHUB_OUTPUT
           echo "Preview deployed to: $url"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run Trivy in table format for PR comment
         if: github.event_name == 'pull_request'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -94,7 +94,7 @@ jobs:
 
             Quality Gate analysis complete. View detailed results:
 
-            🔗 [SonarCloud Dashboard](https://sonarcloud.io/summary/new_code?id=car-rental-management-system)
+            🔗 [SonarCloud Dashboard](https://sonarcloud.io/summary/new_code?id=SolombrinoIsmail_car-rental-management-system)
 
             ### Key Metrics
             - **Reliability** - Bugs and issues


### PR DESCRIPTION
This PR hardens CI/CD:

- Pin actions (Trivy @ v0.20.0, TruffleHog @ v3.82.10)
- Add least-privilege permissions blocks and preview concurrency
- Use env-based Vercel token instead of CLI flags
- Guard PR-only comments in deploy workflow
- Fix package filter for database and correct SonarCloud dashboard link
- Make pnpm audit non-blocking (security.yml still covers scanning)

Notes:
- No app code changes.
- Push hook ran tests; database tests failed locally due to missing local DB — CI uses service container.

Please review and merge.